### PR TITLE
[#434] 実行中のWORKFLOWID表示

### DIFF
--- a/frontend/src/components/Experiment/Button/DeleteButton.tsx
+++ b/frontend/src/components/Experiment/Button/DeleteButton.tsx
@@ -8,6 +8,7 @@ import DialogTitle from '@mui/material/DialogTitle'
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
 import { selectExperimentName } from 'store/slice/Experiments/ExperimentsSelectors'
 import { deleteExperimentByUid } from 'store/slice/Experiments/ExperimentsActions'
+import { clearCurrentPipeline } from 'store/slice/Pipeline/PipelineSlice'
 import { ExperimentUidContext } from '../ExperimentTable'
 import {
   selectPipelineLatestUid,
@@ -17,6 +18,7 @@ import { RootState } from 'store/store'
 
 export const DeleteButton = React.memo(() => {
   const dispatch = useDispatch()
+  const currentPipelineUid = useSelector(selectPipelineLatestUid)
   const uid = React.useContext(ExperimentUidContext)
   const isRunning = useSelector((state: RootState) => {
     const currentUid = selectPipelineLatestUid(state)
@@ -35,6 +37,7 @@ export const DeleteButton = React.memo(() => {
   const onClickOk = () => {
     setOpen(false)
     dispatch(deleteExperimentByUid(uid))
+    uid === currentPipelineUid && dispatch(clearCurrentPipeline())
   }
   return (
     <>

--- a/frontend/src/components/Experiment/ExperimentTable.tsx
+++ b/frontend/src/components/Experiment/ExperimentTable.tsx
@@ -51,6 +51,8 @@ import { ImportButton } from './Button/ImportButton'
 import { useLocalStorage } from 'components/utils/LocalStorageUtil'
 import { styled } from '@mui/material/styles'
 import { renameExperiment } from 'api/experiments/Experiments'
+import { selectPipelineLatestUid } from 'store/slice/Pipeline/PipelineSelectors'
+import { clearCurrentPipeline } from 'store/slice/Pipeline/PipelineSlice'
 
 export const ExperimentUidContext = React.createContext<string>('')
 
@@ -87,6 +89,7 @@ const ExperimentsErrorView: React.FC = () => {
 const LOCAL_STORAGE_KEY_PER_PAGE = 'optinist_experiment_table_per_page'
 
 const TableImple = React.memo(() => {
+  const currentPipelineUid = useSelector(selectPipelineLatestUid)
   const experimentList = useSelector(selectExperimentList)
   const experimentListValues = Object.values(experimentList)
   const experimentListKeys = Object.keys(experimentList)
@@ -133,6 +136,8 @@ const TableImple = React.memo(() => {
   }
   const onClickOk = () => {
     dispatch(deleteExperimentByList(checkedList))
+    checkedList.filter((v) => v === currentPipelineUid).length > 0 &&
+      dispatch(clearCurrentPipeline())
     setCheckedList([])
     setOpen(false)
   }

--- a/frontend/src/components/FlowChart/FlowChart.tsx
+++ b/frontend/src/components/FlowChart/FlowChart.tsx
@@ -11,6 +11,7 @@ import { ReactFlowComponent } from './ReactFlowComponent'
 import RightDrawer, { rightDrawerWidth } from './RightDrawer'
 import { selectRightDrawerIsOpen } from 'store/slice/RightDrawer/RightDrawerSelectors'
 import { UseRunPipelineReturnType } from 'store/slice/Pipeline/PipelineHook'
+import { CurrentPipelineInfo } from 'components/common/CurrentPipelineInfo'
 
 const FlowChart = React.memo<UseRunPipelineReturnType>((props) => {
   const open = useSelector(selectRightDrawerIsOpen)
@@ -19,6 +20,7 @@ const FlowChart = React.memo<UseRunPipelineReturnType>((props) => {
       <DndProvider backend={HTML5Backend}>
         <StyledDrawer variant="permanent">
           <MuiToolbar />
+          <CurrentPipelineInfo />
           <DrawerContents>
             <AlgorithmTreeView />
           </DrawerContents>

--- a/frontend/src/components/Visualize/Visualize.tsx
+++ b/frontend/src/components/Visualize/Visualize.tsx
@@ -12,8 +12,8 @@ const Visualize: React.FC = () => {
     <RootDiv>
       <StyledDrawer variant="permanent">
         <MuiToolbar />
+        <CurrentPipelineInfo />
         <StyledDrawerContents>
-          <CurrentPipelineInfo />
           <VisualizeItemEditor />
         </StyledDrawerContents>
       </StyledDrawer>

--- a/frontend/src/components/Visualize/Visualize.tsx
+++ b/frontend/src/components/Visualize/Visualize.tsx
@@ -5,6 +5,7 @@ import { styled } from '@mui/material/styles'
 import { drawerWidth } from 'components/FlowChart/FlowChart'
 import { FlexItemList } from './FlexItemList'
 import { VisualizeItemEditor } from './VisualizeItemEditor'
+import { CurrentPipelineInfo } from 'components/common/CurrentPipelineInfo'
 
 const Visualize: React.FC = () => {
   return (
@@ -12,6 +13,7 @@ const Visualize: React.FC = () => {
       <StyledDrawer variant="permanent">
         <MuiToolbar />
         <StyledDrawerContents>
+          <CurrentPipelineInfo />
           <VisualizeItemEditor />
         </StyledDrawerContents>
       </StyledDrawer>

--- a/frontend/src/components/common/CurrentPipelineInfo.tsx
+++ b/frontend/src/components/common/CurrentPipelineInfo.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { selectPipelineLatestUid } from 'store/slice/Pipeline/PipelineSelectors'
-import { List, ListItem, ListSubheader, Divider } from '@mui/material'
+import { Divider, Typography, Grid } from '@mui/material'
 import {
   selectExperimentName,
   selectExperimentsSatusIsFulfilled,
@@ -24,10 +24,10 @@ export const CurrentPipelineInfo: React.FC = () => {
     <>
       {uid && (
         <>
-          <List dense>
+          <Grid container paddingX={2} paddingBottom={1}>
             <ExperimentUidInfo uid={uid} />
             {isFulFilled && <ExperimentNameInfo uid={uid} />}
-          </List>
+          </Grid>
           <Divider />
         </>
       )}
@@ -36,20 +36,29 @@ export const CurrentPipelineInfo: React.FC = () => {
 }
 
 const ExperimentUidInfo = React.memo<{ uid: string }>(({ uid }) => {
-  return (
-    <>
-      <ListSubheader>ID</ListSubheader>
-      <ListItem>{uid}</ListItem>
-    </>
-  )
+  return <LabelValueGridRow label="ID" value={uid} />
 })
 
 const ExperimentNameInfo = React.memo<{ uid: string }>(({ uid }) => {
   const name = useSelector(selectExperimentName(uid))
-  return (
-    <>
-      <ListSubheader>NAME</ListSubheader>
-      <ListItem>{name}</ListItem>
-    </>
-  )
+  return <LabelValueGridRow label="NAME" value={name} />
 })
+
+const LabelValueGridRow = React.memo<{ label: string; value: string }>(
+  ({ label, value }) => {
+    return (
+      <>
+        <Grid item xs={4}>
+          <Typography variant="body2" color="textSecondary">
+            {label}:
+          </Typography>
+        </Grid>
+        <Grid item xs={8}>
+          <Typography variant="body2" color="textSecondary">
+            {value}
+          </Typography>
+        </Grid>
+      </>
+    )
+  },
+)

--- a/frontend/src/components/common/CurrentPipelineInfo.tsx
+++ b/frontend/src/components/common/CurrentPipelineInfo.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { useSelector, useDispatch } from 'react-redux'
+import { selectPipelineLatestUid } from 'store/slice/Pipeline/PipelineSelectors'
+import { List, ListItem, ListSubheader, Divider } from '@mui/material'
+import {
+  selectExperimentName,
+  selectExperimentsSatusIsFulfilled,
+  selectExperimentsSatusIsUninitialized,
+} from 'store/slice/Experiments/ExperimentsSelectors'
+import { getExperiments } from 'store/slice/Experiments/ExperimentsActions'
+
+export const CurrentPipelineInfo: React.FC = () => {
+  const uid = useSelector(selectPipelineLatestUid)
+  const isUninitialized = useSelector(selectExperimentsSatusIsUninitialized)
+  const isFulFilled = useSelector(selectExperimentsSatusIsFulfilled)
+  const dispatch = useDispatch()
+  React.useEffect(() => {
+    if (isUninitialized) {
+      dispatch(getExperiments())
+    }
+  }, [dispatch, isUninitialized])
+
+  return (
+    <>
+      {uid && (
+        <>
+          <List dense>
+            <ExperimentUidInfo uid={uid} />
+            {isFulFilled && <ExperimentNameInfo uid={uid} />}
+          </List>
+          <Divider />
+        </>
+      )}
+    </>
+  )
+}
+
+const ExperimentUidInfo = React.memo<{ uid: string }>(({ uid }) => {
+  return (
+    <>
+      <ListSubheader>ID</ListSubheader>
+      <ListItem>{uid}</ListItem>
+    </>
+  )
+})
+
+const ExperimentNameInfo = React.memo<{ uid: string }>(({ uid }) => {
+  const name = useSelector(selectExperimentName(uid))
+  return (
+    <>
+      <ListSubheader>NAME</ListSubheader>
+      <ListItem>{name}</ListItem>
+    </>
+  )
+})

--- a/frontend/src/store/slice/Pipeline/PipelineSlice.ts
+++ b/frontend/src/store/slice/Pipeline/PipelineSlice.ts
@@ -37,6 +37,7 @@ export const pipelineSlice = createSlice({
     ) => {
       state.runBtn = action.payload.runBtnOption
     },
+    clearCurrentPipeline: () => initialState,
   },
   extraReducers: (builder) => {
     builder
@@ -102,6 +103,7 @@ export const pipelineSlice = createSlice({
   },
 })
 
-export const { cancelPipeline, setRunBtnOption } = pipelineSlice.actions
+export const { cancelPipeline, setRunBtnOption, clearCurrentPipeline } =
+  pipelineSlice.actions
 
 export default pipelineSlice.reducer


### PR DESCRIPTION
#434 

## 実装概要
WORKFLOWおよびVISUALIZEタブにて、最終実行したIDおよびNAME（RECORDタブで表示されるもの）を表示

![Screenshot 2023-04-20 at 15 59 24](https://user-images.githubusercontent.com/42664619/233290307-5ea78ed2-0b0f-417d-8a3d-210812983769.png)
![Screenshot 2023-04-20 at 15 59 39](https://user-images.githubusercontent.com/42664619/233290317-b373a456-913b-475a-8082-8d46bbcba51d.png)

## 備考
### DELETE時の仕様について
- 最終実行IDがRECORD画面操作で削除された場合は非表示。
- それ以外のIDの削除は表示に影響しない。
- 複数/単体選択削除、削除対象に最終実行IDを含む/含まないの4パターンで動作を確認済。

### ビルドについて
- develop-mainへのフロントのビルドは無しにする方針に転換予定のため、本PRからビルドはコミットに含めていません。