### PR TITLE
[#429] outputディレクトリのユニーク化

### DIFF
--- a/optinist/api/dataclass/image.py
+++ b/optinist/api/dataclass/image.py
@@ -11,7 +11,7 @@ from optinist.api.dataclass.base import BaseData
 
 
 class ImageData(BaseData):
-    def __init__(self, data, file_name='image'):
+    def __init__(self, data, output_dir=DIRPATH.OUTPUT_DIR, file_name='image'):
         super().__init__(file_name)
 
         self.json_path = None
@@ -23,7 +23,7 @@ class ImageData(BaseData):
         elif isinstance(data, list) and isinstance(data[0], str):
             self.path = data
         else:
-            _dir = join_filepath([DIRPATH.OUTPUT_DIR, "tiff", file_name])
+            _dir = join_filepath([output_dir, "tiff", file_name])
             create_directory(_dir)
 
             _path = join_filepath([_dir, f'{file_name}.tif'])
@@ -49,12 +49,12 @@ class ImageData(BaseData):
 
 
 class RoiData(BaseData):
-    def __init__(self, data, file_name='roi'):
+    def __init__(self, data, output_dir=DIRPATH.OUTPUT_DIR, file_name='roi'):
         super().__init__(file_name)
 
         images = create_images_list(data)
 
-        _dir = join_filepath([DIRPATH.OUTPUT_DIR, "tiff", file_name])
+        _dir = join_filepath([output_dir, "tiff", file_name])
         create_directory(_dir)
         self.path = join_filepath([_dir, f'{file_name}.tif'])
         tifffile.imsave(self.path, images)

--- a/optinist/api/rules/runner.py
+++ b/optinist/api/rules/runner.py
@@ -30,6 +30,7 @@ class Runner:
             output_info = cls.execute_function(
                 __rule.path,
                 __rule.params,
+                os.path.dirname(__rule.output),
                 input_info
             )
 
@@ -90,13 +91,13 @@ class Runner:
         )
 
     @classmethod
-    def execute_function(cls, path, params, input_info):
+    def execute_function(cls, path, params, output_dir, input_info):
         wrapper = cls.dict2leaf(
             wrapper_dict,
             path.split('/')
         )
         func = copy.deepcopy(wrapper["function"])
-        output_info = func(params=params, **input_info)
+        output_info = func(params=params, output_dir=output_dir, **input_info)
         del func
         gc.collect()
 

--- a/optinist/routers/const.py
+++ b/optinist/routers/const.py
@@ -2,4 +2,4 @@ ACCEPT_TIFF_EXT = [".tif", ".tiff", ".TIF", ".TIFF"]
 ACCEPT_CSV_EXT = [".csv"]
 ACCEPT_HDF5_EXT = [".hdf5", ".nwb", ".HDF5", ".NWB"]
 
-NOT_DISPLAY_ARGS_LIST = ['params', 'nwbfile']
+NOT_DISPLAY_ARGS_LIST = ['params', 'output_dir', 'nwbfile']

--- a/optinist/wrappers/caiman_wrapper/cnmf.py
+++ b/optinist/wrappers/caiman_wrapper/cnmf.py
@@ -210,12 +210,12 @@ def caiman_cnmf(
     ])
 
     info = {
-        'images': ImageData(np.array(Cn * 255, dtype=np.uint8), file_name='images'),
+        'images': ImageData(np.array(Cn * 255, dtype=np.uint8), output_dir=output_dir, file_name='images'),
         'fluorescence': FluoData(fluorescence, file_name='fluorescence'),
         'iscell': IscellData(iscell, file_name='iscell'),
-        'all_roi': RoiData(all_roi, file_name='all_roi'),
-        'cell_roi': RoiData(cell_roi, file_name='cell_roi'),
-        'non_cell_roi': RoiData(non_cell_roi, file_name='non_cell_roi'),
+        'all_roi': RoiData(all_roi, output_dir=output_dir, file_name='all_roi'),
+        'cell_roi': RoiData(cell_roi, output_dir=output_dir, file_name='cell_roi'),
+        'non_cell_roi': RoiData(non_cell_roi, output_dir=output_dir, file_name='non_cell_roi'),
         'nwbfile': nwbfile
     }
 

--- a/optinist/wrappers/caiman_wrapper/cnmf.py
+++ b/optinist/wrappers/caiman_wrapper/cnmf.py
@@ -57,9 +57,10 @@ def get_roi(A, thr, thr_method, swap_dim, dims):
 
 
 def caiman_cnmf(
-        images: ImageData,
-        params: dict=None
-    ) -> dict(fluorescence=FluoData, iscell=IscellData):
+    images: ImageData,
+    output_dir: str,
+    params: dict = None
+) -> dict(fluorescence=FluoData, iscell=IscellData):
     from caiman import local_correlations, stop_server
     from caiman.paths import memmap_frames_filename
     from caiman.mmapping import prepare_shape

--- a/optinist/wrappers/caiman_wrapper/motion_correction.py
+++ b/optinist/wrappers/caiman_wrapper/motion_correction.py
@@ -3,9 +3,10 @@ from optinist.api.nwb.nwb import NWBDATASET
 
 
 def caiman_mc(
-        image: ImageData,
-        params: dict=None
-    ) -> dict(mc_images=ImageData):
+    image: ImageData,
+    output_dir: str,
+    params: dict = None
+) -> dict(mc_images=ImageData):
     import numpy as np
     from caiman import load, save_memmap, load_memmap, stop_server
     from caiman.source_extraction.cnmf.params import CNMFParams

--- a/optinist/wrappers/caiman_wrapper/motion_correction.py
+++ b/optinist/wrappers/caiman_wrapper/motion_correction.py
@@ -56,7 +56,7 @@ def caiman_mc(
     xy_trans_data = (np.array(mc.x_shifts_els), np.array(mc.y_shifts_els)) \
                     if params['pw_rigid'] else np.array(mc.shifts_rig)
 
-    mc_images = ImageData(images, file_name='mc_images')
+    mc_images = ImageData(images, output_dir=output_dir, file_name='mc_images')
 
     nwbfile = {}
     nwbfile[NWBDATASET.MOTION_CORRECTION] = {
@@ -68,8 +68,8 @@ def caiman_mc(
 
     info = {
         'mc_images': mc_images,
-        'meanImg': ImageData(meanImg, file_name='meanImg'),
-        'rois': RoiData(rois, file_name='rois'),
+        'meanImg': ImageData(meanImg, output_dir=output_dir, file_name='meanImg'),
+        'rois': RoiData(rois, output_dir=output_dir, file_name='rois'),
         'nwbfile': nwbfile,
     }
 

--- a/optinist/wrappers/lccd_wrapper/lccd_detection.py
+++ b/optinist/wrappers/lccd_wrapper/lccd_detection.py
@@ -3,7 +3,9 @@ import numpy as np
 
 
 def lccd_detect(
-    mc_images: ImageData, params: dict = None
+    mc_images: ImageData,
+    output_dir: str,
+    params: dict = None
 ) -> dict(fluorescence=FluoData, cell_roi=RoiData):
     from .lccd_python.lccd import LCCD
 

--- a/optinist/wrappers/lccd_wrapper/lccd_detection.py
+++ b/optinist/wrappers/lccd_wrapper/lccd_detection.py
@@ -42,7 +42,7 @@ def lccd_detect(
                 timeseries_dff[i, k] = (timeseries[i, k] - f0) / f0
 
     info = {
-        'rois': RoiData(np.nanmax(roi_list, axis=0), file_name='cell_roi'),
+        'rois': RoiData(np.nanmax(roi_list, axis=0), output_dir=output_dir, file_name='cell_roi'),
         'fluorescence': FluoData(timeseries, file_name='fluorescence'),
         'dff': FluoData(timeseries_dff, file_name='dff'),
     }

--- a/optinist/wrappers/optinist_wrapper/basic_neural_analysis/cell_grouping.py
+++ b/optinist/wrappers/optinist_wrapper/basic_neural_analysis/cell_grouping.py
@@ -2,10 +2,11 @@ from optinist.api.dataclass.dataclass import *
 
 
 def cell_grouping(
-        neural_data: TimeSeriesData,
-        nwbfile: NWBFile=None,
-        params: dict=None
-    ) -> dict():
+    neural_data: TimeSeriesData,
+    nwbfile: NWBFile=None,
+    output_dir: str,
+    params: dict = None
+) -> dict():
     import numpy as np
 
     neural_data = neural_data.data

--- a/optinist/wrappers/optinist_wrapper/basic_neural_analysis/eta.py
+++ b/optinist/wrappers/optinist_wrapper/basic_neural_analysis/eta.py
@@ -35,11 +35,12 @@ def calc_trigger_average(neural_data, trigger_idx, start_time, end_time):
 
 
 def ETA(
-        neural_data: FluoData,
-        behaviors_data: BehaviorData,
-        iscell: IscellData=None,
-        params: dict=None
-    ) -> dict(mean=TimeSeriesData):
+    neural_data: FluoData,
+    behaviors_data: BehaviorData,
+    output_dir: str,
+    iscell: IscellData = None,
+    params: dict = None
+) -> dict(mean=TimeSeriesData):
     import numpy as np
 
     neural_data = neural_data.data

--- a/optinist/wrappers/optinist_wrapper/dimension_reduction/cca.py
+++ b/optinist/wrappers/optinist_wrapper/dimension_reduction/cca.py
@@ -3,11 +3,12 @@ from optinist.wrappers.optinist_wrapper.utils import standard_norm
 from optinist.api.nwb.nwb import NWBDATASET
 
 def CCA(
-        neural_data: FluoData,
-        behaviors_data: BehaviorData,
-        iscell: IscellData=None,
-        params: dict=None
-    ) -> dict():
+    neural_data: FluoData,
+    behaviors_data: BehaviorData,
+    output_dir: str,
+    iscell: IscellData = None,
+    params: dict = None
+) -> dict():
 
     from sklearn.cross_decomposition import CCA
 

--- a/optinist/wrappers/optinist_wrapper/dimension_reduction/pca.py
+++ b/optinist/wrappers/optinist_wrapper/dimension_reduction/pca.py
@@ -3,10 +3,11 @@ from optinist.wrappers.optinist_wrapper.utils import standard_norm
 from optinist.api.nwb.nwb import NWBDATASET
 
 def PCA(
-        neural_data: FluoData,
-        iscell: IscellData=None,
-        params: dict=None
-    ) -> dict():
+    neural_data: FluoData,
+    output_dir: str,
+    iscell: IscellData = None,
+    params: dict = None
+) -> dict():
 
     # modules specific to function
     from sklearn.decomposition import PCA

--- a/optinist/wrappers/optinist_wrapper/dimension_reduction/tsne.py
+++ b/optinist/wrappers/optinist_wrapper/dimension_reduction/tsne.py
@@ -3,10 +3,11 @@ from optinist.wrappers.optinist_wrapper.utils import standard_norm
 from optinist.api.nwb.nwb import NWBDATASET
 
 def TSNE(
-        neural_data: FluoData,
-        iscell: IscellData=None,
-        params: dict=None
-    ) -> dict():
+    neural_data: FluoData,
+    output_dir: str,
+    iscell: IscellData = None,
+    params: dict = None
+) -> dict():
 
     from sklearn.manifold import TSNE
 

--- a/optinist/wrappers/optinist_wrapper/neural_decoding/glm.py
+++ b/optinist/wrappers/optinist_wrapper/neural_decoding/glm.py
@@ -9,11 +9,12 @@ from optinist.wrappers.optinist_wrapper.utils import standard_norm
 from optinist.api.nwb.nwb import NWBDATASET
 
 def GLM(
-        neural_data: FluoData,
-        behaviors_data: BehaviorData,
-        iscell: IscellData=None,
-        params: dict=None
-    ) -> dict():
+    neural_data: FluoData,
+    behaviors_data: BehaviorData,
+    output_dir: str,
+    iscell: IscellData = None,
+    params: dict = None
+) -> dict():
 
     # modules specific to function
     import statsmodels.api as sm

--- a/optinist/wrappers/optinist_wrapper/neural_decoding/lda.py
+++ b/optinist/wrappers/optinist_wrapper/neural_decoding/lda.py
@@ -3,11 +3,12 @@ from optinist.wrappers.optinist_wrapper.utils import standard_norm
 from optinist.api.nwb.nwb import NWBDATASET
 
 def LDA(
-        neural_data: FluoData,
-        behaviors_data: BehaviorData,
-        iscell: IscellData=None,
-        params: dict=None
-    ) -> dict():
+    neural_data: FluoData,
+    behaviors_data: BehaviorData,
+    output_dir: str,
+    iscell: IscellData = None,
+    params: dict = None
+) -> dict():
 
     # modules specific to function
     from sklearn.discriminant_analysis import LinearDiscriminantAnalysis as LDA

--- a/optinist/wrappers/optinist_wrapper/neural_decoding/svm.py
+++ b/optinist/wrappers/optinist_wrapper/neural_decoding/svm.py
@@ -3,11 +3,12 @@ from optinist.wrappers.optinist_wrapper.utils import standard_norm
 from optinist.api.nwb.nwb import NWBDATASET
 
 def SVM(
-        neural_data: FluoData,
-        behaviors_data: BehaviorData,
-        iscell: IscellData=None,
-        params: dict=None
-    ) -> dict():
+    neural_data: FluoData,
+    behaviors_data: BehaviorData,
+    output_dir: str,
+    iscell: IscellData = None,
+    params: dict = None
+) -> dict():
 
     # modules specific to function
     import numpy as np

--- a/optinist/wrappers/optinist_wrapper/neural_population_analysis/correlation.py
+++ b/optinist/wrappers/optinist_wrapper/neural_population_analysis/correlation.py
@@ -3,10 +3,11 @@ from optinist.api.nwb.nwb import NWBDATASET
 
 
 def correlation(
-        neural_data: FluoData,
-        iscell: IscellData=None,
-        params: dict=None
-    ) -> dict():
+    neural_data: FluoData,
+    output_dir: str,
+    iscell: IscellData = None,
+    params: dict = None
+) -> dict():
 
     neural_data = neural_data.data
 

--- a/optinist/wrappers/optinist_wrapper/neural_population_analysis/cross_correlation.py
+++ b/optinist/wrappers/optinist_wrapper/neural_population_analysis/cross_correlation.py
@@ -3,10 +3,11 @@ from optinist.api.nwb.nwb import NWBDATASET
 
 
 def cross_correlation(
-        neural_data: FluoData,
-        iscell: IscellData=None,
-        params: dict=None
-    ) -> dict():
+    neural_data: FluoData,
+    output_dir: str,
+    iscell: IscellData = None,
+    params: dict = None
+) -> dict():
 
     import scipy.signal as ss
     import itertools

--- a/optinist/wrappers/optinist_wrapper/neural_population_analysis/granger.py
+++ b/optinist/wrappers/optinist_wrapper/neural_population_analysis/granger.py
@@ -4,10 +4,11 @@ from optinist.api.nwb.nwb import NWBDATASET
 
 
 def Granger(
-        neural_data: FluoData,
-        iscell: IscellData=None,
-        params: dict=None
-    ) -> dict():
+    neural_data: FluoData,
+    output_dir: str,
+    iscell: IscellData = None,
+    params: dict = None
+) -> dict():
 
     # modules specific to function
     # from sklearn.preprocessing import StandardScaler

--- a/optinist/wrappers/suite2p_wrapper/file_convert.py
+++ b/optinist/wrappers/suite2p_wrapper/file_convert.py
@@ -1,7 +1,6 @@
 import os
 
 from optinist.api.dataclass.dataclass import *
-from optinist.api.dir_path import DIRPATH
 from optinist.api.utils.filepath_creater import join_filepath
 
 
@@ -25,7 +24,7 @@ def suite2p_file_convert(
     db = {
         'data_path': data_path_list,
         'tiff_list': data_name_list,
-        'save_path0': DIRPATH.OUTPUT_DIR,
+        'save_path0': output_dir,
         'save_folder': 'suite2p'
     }
 
@@ -40,7 +39,7 @@ def suite2p_file_convert(
     ops = io.tiff_to_binary(ops.copy())
 
     info = {
-        'meanImg': ImageData(ops['meanImg'], file_name='meanImg'),
+        'meanImg': ImageData(ops['meanImg'], output_dir=output_dir, file_name='meanImg'),
         'ops': Suite2pData(ops, file_name='ops')
     }
 

--- a/optinist/wrappers/suite2p_wrapper/file_convert.py
+++ b/optinist/wrappers/suite2p_wrapper/file_convert.py
@@ -6,9 +6,10 @@ from optinist.api.utils.filepath_creater import join_filepath
 
 
 def suite2p_file_convert(
-        image: ImageData,
-        params: dict=None
-    ) -> dict(ops=Suite2pData):
+    image: ImageData,
+    output_dir: str,
+    params: dict = None
+) -> dict(ops=Suite2pData):
     from suite2p import io, default_ops
     print('start suite2_file_convert')
 

--- a/optinist/wrappers/suite2p_wrapper/registration.py
+++ b/optinist/wrappers/suite2p_wrapper/registration.py
@@ -25,8 +25,8 @@ def suite2p_registration(
         ops = registration.get_pc_metrics(ops)
 
     info = {
-        'refImg': ImageData(ops['refImg'], file_name='refImg'),
-        'meanImgE': ImageData(ops['meanImgE'], file_name='meanImgE'),
+        'refImg': ImageData(ops['refImg'], output_dir=output_dir, file_name='refImg'),
+        'meanImgE': ImageData(ops['meanImgE'], output_dir=output_dir, file_name='meanImgE'),
         'ops': Suite2pData(ops, file_name='ops'),
     }
 

--- a/optinist/wrappers/suite2p_wrapper/registration.py
+++ b/optinist/wrappers/suite2p_wrapper/registration.py
@@ -2,9 +2,10 @@ from optinist.api.dataclass.dataclass import *
 
 
 def suite2p_registration(
-        ops: Suite2pData,
-        params: dict=None
-    ) -> dict(ops=Suite2pData):
+    ops: Suite2pData,
+    output_dir: str,
+    params: dict = None
+) -> dict(ops=Suite2pData):
     from suite2p import registration, default_ops
     ops = ops.data
     refImg = ops['meanImg']

--- a/optinist/wrappers/suite2p_wrapper/roi.py
+++ b/optinist/wrappers/suite2p_wrapper/roi.py
@@ -3,9 +3,10 @@ from optinist.api.nwb.nwb import NWBDATASET
 
 
 def suite2p_roi(
-        ops: Suite2pData,
-        params: dict=None
-    ) -> dict(ops=Suite2pData, fluorescence=FluoData, iscell=IscellData):
+    ops: Suite2pData,
+    output_dir: str,
+    params: dict = None
+) -> dict(ops=Suite2pData, fluorescence=FluoData, iscell=IscellData):
     import numpy as np
     from suite2p import extraction, classification, detection, ROI, default_ops
     print('start suite2p_roi')

--- a/optinist/wrappers/suite2p_wrapper/roi.py
+++ b/optinist/wrappers/suite2p_wrapper/roi.py
@@ -93,13 +93,13 @@ def suite2p_roi(
 
     info = {
         'ops': Suite2pData(ops),
-        'max_proj': ImageData(ops['max_proj'], file_name='max_proj'),
-        'Vcorr': ImageData(ops['Vcorr'], file_name='Vcorr'),
+        'max_proj': ImageData(ops['max_proj'], output_dir=output_dir, file_name='max_proj'),
+        'Vcorr': ImageData(ops['Vcorr'], output_dir=output_dir, file_name='Vcorr'),
         'fluorescence': FluoData(F, file_name='fluorescence'),
         'iscell': IscellData(iscell, file_name='iscell'),
-        'all_roi': RoiData(np.nanmax(im, axis=0), file_name='all_roi'),
-        'non_cell_roi': RoiData(np.nanmax(im[~iscell], axis=0), file_name='noncell_roi'),
-        'cell_roi': RoiData(np.nanmax(im[iscell], axis=0), file_name='cell_roi'),
+        'all_roi': RoiData(np.nanmax(im, axis=0), output_dir=output_dir, file_name='all_roi'),
+        'non_cell_roi': RoiData(np.nanmax(im[~iscell], axis=0), output_dir=output_dir, file_name='noncell_roi'),
+        'cell_roi': RoiData(np.nanmax(im[iscell], axis=0), output_dir=output_dir, file_name='cell_roi'),
         'nwbfile': nwbfile,
     }
 

--- a/optinist/wrappers/suite2p_wrapper/spike_deconv.py
+++ b/optinist/wrappers/suite2p_wrapper/spike_deconv.py
@@ -3,9 +3,10 @@ from optinist.api.nwb.nwb import NWBDATASET
 
 
 def suite2p_spike_deconv(
-        ops: Suite2pData,
-        params: dict=None
-    ) -> dict(ops=Suite2pData, spks=FluoData):
+    ops: Suite2pData,
+    output_dir: str,
+    params: dict = None
+) -> dict(ops=Suite2pData, spks=FluoData):
     from suite2p import extraction, default_ops
     print('start suite2_spike_deconv')
     ops = ops.data


### PR DESCRIPTION
#429 

## 概要
ImageData, RoiDataのoutput pathがoutput/tiff配下になっており、ワークフロー・関数単位でユニークではない問題を修正

## 修正内容
- snakemake configファイル(config.yaml)の関数毎の最終outputの出力先ディレクトリをユニークな出力先パスとして利用
  - 例：`output/962aaefb/caiman_mc_njrnnpgq99/`
- 各wrapper関数のパラメータとして上記パスを追加
  - `NOT_DISPLAY_ARGS_LIST`に追加し、ユーザーが指定可能なパラメータ表示から除外
- ファイルの保存先に上記パスを指定
  - ImageData, RoiData
  - Suite2pのfile_convert関数：tiff_to_binaryの出力先(`save_path0`)として指定

## 検証
以下の3つのワークフローについて、REPRODUCEの問題解消の確認（各ワークフローで、Inputのファイルを差し替えた2パターンでRUN_ALLを実行し、初回実行ワークフローをREPRODUCE -> RUN）を実施
いずれのケースでも、REPRODUCEしたワークフローの出力が得られることを確認した

![caiman_1_workflow](https://user-images.githubusercontent.com/42664619/233890617-172999cc-bf52-43a1-8649-4b3a1254e965.png)
![lccd_1_workflow](https://user-images.githubusercontent.com/42664619/233890622-30108a15-b3f5-4afa-97ea-4e52a83fd349.png)
![suite2p_1_workflow](https://user-images.githubusercontent.com/42664619/233890625-bc853b91-c214-4434-a4d1-270fc3295a2e.png)

