### PR TITLE
最終実行ワークフローの保持

### DIFF
--- a/frontend/src/api/experiments/Experiments.ts
+++ b/frontend/src/api/experiments/Experiments.ts
@@ -28,6 +28,11 @@ export async function getExperimentsApi(): Promise<ExperimentsDTO> {
   return response.data
 }
 
+export async function getLastExperimentUidApi(): Promise<string> {
+  const response = await axios.get(`${BASE_URL}/experiments/last`)
+  return response.data
+}
+
 export async function deleteExperimentByUidApi(uid: string): Promise<boolean> {
   const response = await axios.delete(`${BASE_URL}/experiments/${uid}`)
   return response.data

--- a/frontend/src/store/slice/Experiments/ExperimentsActions.ts
+++ b/frontend/src/store/slice/Experiments/ExperimentsActions.ts
@@ -2,6 +2,7 @@ import { createAsyncThunk } from '@reduxjs/toolkit'
 import {
   ExperimentsDTO,
   getExperimentsApi,
+  getLastExperimentUidApi,
   deleteExperimentByUidApi,
   importExperimentByUidApi,
   deleteExperimentByListApi,
@@ -14,6 +15,18 @@ export const getExperiments = createAsyncThunk<ExperimentsDTO, undefined>(
   async (_, thunkAPI) => {
     try {
       const response = await getExperimentsApi()
+      return response
+    } catch (e) {
+      return thunkAPI.rejectWithValue(e)
+    }
+  },
+)
+
+export const getLastExperimentUid = createAsyncThunk<string, undefined>(
+  `${EXPERIMENTS_SLICE_NAME}/getLastExperiment`,
+  async (_, thunkAPI) => {
+    try {
+      const response = await getLastExperimentUidApi()
       return response
     } catch (e) {
       return thunkAPI.rejectWithValue(e)

--- a/frontend/src/store/slice/Pipeline/PipelineSlice.ts
+++ b/frontend/src/store/slice/Pipeline/PipelineSlice.ts
@@ -1,5 +1,8 @@
 import { createSlice, isAnyOf, PayloadAction } from '@reduxjs/toolkit'
-import { importExperimentByUid } from '../Experiments/ExperimentsActions'
+import {
+  getLastExperimentUid,
+  importExperimentByUid,
+} from '../Experiments/ExperimentsActions'
 import { pollRunResult, run, runByCurrentUid } from './PipelineActions'
 import {
   Pipeline,
@@ -58,6 +61,9 @@ export const pipelineSlice = createSlice({
       })
       .addCase(pollRunResult.rejected, (state, action) => {
         state.run.status = RUN_STATUS.ABORTED
+      })
+      .addCase(getLastExperimentUid.fulfilled, (state, action) => {
+        state.currentPipeline = { uid: action.payload }
       })
       .addCase(importExperimentByUid.fulfilled, (state, action) => {
         state.currentPipeline = {

--- a/optinist/api/dir_path.py
+++ b/optinist/api/dir_path.py
@@ -25,3 +25,4 @@ class DIRPATH:
     SNAKEMAKE_FILEPATH = f"{ROOT_DIR}/Snakefile"
     EXPERIMENT_YML = "experiment.yaml"
     SNAKEMAKE_CONFIG_YML = "config.yaml"
+    WORKFLOW_YML = "workflow.yaml"

--- a/optinist/api/workflow/workflow.py
+++ b/optinist/api/workflow/workflow.py
@@ -6,6 +6,11 @@ from optinist.api.snakemake.smk import ForceRun
 
 
 @dataclass
+class LastWorkflow:
+    uid: str
+
+
+@dataclass
 class NodeType:
     IMAGE: str = "ImageFileNode"
     CSV: str = "CsvFileNode"

--- a/optinist/routers/run.py
+++ b/optinist/routers/run.py
@@ -2,6 +2,8 @@ from typing import Dict
 from fastapi import APIRouter, BackgroundTasks
 import uuid
 
+from optinist.api.dir_path import DIRPATH
+from optinist.api.config.config_writer import ConfigWriter
 from optinist.api.workflow.workflow import NodeItem, RunItem, Message
 from optinist.api.workflow.workflow_runner import WorkflowRunner
 from optinist.api.workflow.workflow_result import WorkflowResult
@@ -14,6 +16,7 @@ async def run(runItem: RunItem, background_tasks: BackgroundTasks):
     unique_id = str(uuid.uuid4())[:8]
     WorkflowRunner(unique_id, runItem).run_workflow(background_tasks)
     print("run snakemake")
+    write_workflow_config(unique_id=unique_id)
     return unique_id
 
 
@@ -22,9 +25,18 @@ async def run_id(uid: str, runItem: RunItem, background_tasks: BackgroundTasks):
     WorkflowRunner(uid, runItem).run_workflow(background_tasks)
     print("run snakemake")
     print("forcerun list: ", runItem.forceRunList)
+    write_workflow_config(unique_id=uid)
     return uid
 
 
 @router.post("/run/result/{uid}", response_model=Dict[str, Message], tags=['run'])
 async def run_result(uid: str, nodeDict: NodeItem):
     return WorkflowResult(uid).get(nodeDict.pendingNodeIdList)
+
+
+def write_workflow_config(unique_id):
+    ConfigWriter.write(
+        dirname=DIRPATH.OUTPUT_DIR,
+        filename=DIRPATH.WORKFLOW_YML,
+        config={'uid': unique_id}
+    )


### PR DESCRIPTION
本PRは試験実装のため、現状マージはしない

## 概要

- 最後に実行したワークフローを保持
  - リロードを行なった際に、
    - 最終実行ワークフローが自動的に表示される（import）
    - RUNを実行し、ステータスを取得
- 最終実行情報は`output/workflow.yaml`としてuidを保持（要検討）
  - RUN_ALL, RUNの実行の際に上書き
  - deleteに含まれる場合はuidをnullに変更