### PR TITLE
[#490] Recordテーブル更新のトリガー調整

### DIFF
--- a/frontend/src/components/common/CurrentPipelineInfo.tsx
+++ b/frontend/src/components/common/CurrentPipelineInfo.tsx
@@ -1,24 +1,15 @@
 import React from 'react'
-import { useSelector, useDispatch } from 'react-redux'
+import { useSelector } from 'react-redux'
 import { selectPipelineLatestUid } from 'store/slice/Pipeline/PipelineSelectors'
 import { Divider, Typography, Grid } from '@mui/material'
 import {
   selectExperimentName,
   selectExperimentsSatusIsFulfilled,
-  selectExperimentsSatusIsUninitialized,
 } from 'store/slice/Experiments/ExperimentsSelectors'
-import { getExperiments } from 'store/slice/Experiments/ExperimentsActions'
 
 export const CurrentPipelineInfo: React.FC = () => {
   const uid = useSelector(selectPipelineLatestUid)
-  const isUninitialized = useSelector(selectExperimentsSatusIsUninitialized)
   const isFulFilled = useSelector(selectExperimentsSatusIsFulfilled)
-  const dispatch = useDispatch()
-  React.useEffect(() => {
-    if (isUninitialized) {
-      dispatch(getExperiments())
-    }
-  }, [dispatch, isUninitialized])
 
   return (
     <>

--- a/frontend/src/store/slice/Pipeline/PipelineHook.ts
+++ b/frontend/src/store/slice/Pipeline/PipelineHook.ts
@@ -12,6 +12,7 @@ import { run, pollRunResult, runByCurrentUid } from './PipelineActions'
 import { cancelPipeline } from './PipelineSlice'
 import { selectFilePathIsUndefined } from '../InputNode/InputNodeSelectors'
 import { selectAlgorithmNodeNotExist } from '../AlgorithmNode/AlgorithmNodeSelectors'
+import { getExperiments } from '../Experiments/ExperimentsActions'
 import { useSnackbar } from 'notistack'
 import { RUN_STATUS } from './PipelineType'
 
@@ -59,14 +60,19 @@ export function useRunPipeline() {
     if (prevStatus !== status) {
       if (status === RUN_STATUS.FINISHED) {
         enqueueSnackbar('Finished', { variant: 'success' })
+        dispatch(getExperiments())
+      } else if (status === RUN_STATUS.START_SUCCESS) {
+        dispatch(getExperiments())
       } else if (status === RUN_STATUS.ABORTED) {
         enqueueSnackbar('Aborted', { variant: 'error' })
+        dispatch(getExperiments())
       } else if (status === RUN_STATUS.CANCELED) {
         enqueueSnackbar('Canceled', { variant: 'info' })
+        dispatch(getExperiments())
       }
       setPrevStatus(status)
     }
-  }, [status, prevStatus, enqueueSnackbar])
+  }, [dispatch, status, prevStatus, enqueueSnackbar])
   return {
     filePathIsUndefined,
     algorithmNodeNotExist,


### PR DESCRIPTION
#490 

## 概要

Recordテーブルを自動的に更新(`/experiments`から取得)するタイミンングを変更

- Before
  - ワークフロー画面初回表示(≒アプリ起動)直後
  - RUN, RUN_ALLの実行開始成功時
- After
  - アプリ起動後RUN, RUN_ALLを実行する前にRecord画面を開いた時
  - RUN, RUN_ALLの実行開始成功時
  - RUN, RUN_ALLで全ての処理が終了した時

## 備考

- ver 2.0.2の段階では以下のタイミングでの実装だった
  - アプリ起動後RUN, RUN_ALLを実行する前にRecord画面を開いた時
  - RUN, RUN_ALLの**実行開始成功後初めて**Record画面を開いた時
    - そのため、RUN, RUN_ALL実行後、全ての処理が終了する前にRecord画面に遷移していると、NWBファイルのダウンロード可否は更新されない仕様だった
    - ただし、関数ごとの成功・失敗のステータスのみは更新されていた
      https://github.com/oist/optinist/blob/40bd5300c11b4b17aae14bf4f428521b8ae29bc2/frontend/src/store/slice/Experiments/ExperimentsSlice.ts#L53-L65