### PR TITLE
codespell: config, workflow + some typos fixed using codespell.

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,4 @@
+[codespell]
+skip = .git,*.pdf,*.svg
+#
+# ignore-words-list =

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,4 @@
 [codespell]
-skip = .git,*.pdf,*.svg
+skip = .git,*.pdf,*.svg,*.chunk.*,*.lock
 #
 # ignore-words-list =

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,22 @@
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ OptiNiSt also supports reproducibility of scientific research, standardization o
 
 ### Postprocessing
 - [x] Basic Neural Analysis(Event Trigger Average...)
-- [x] Dimenstion Reduction(PCA...)
+- [x] Dimension Reduction(PCA...)
 - [x] Neural Decoding(LDA...)
 - [x] Neural Population Analysis(Correlation...)
 

--- a/docs/gui/visualize.md
+++ b/docs/gui/visualize.md
@@ -151,7 +151,7 @@ The plotting box (ID:0) shows the background image and detected cells.
 </p>
 
 
-You can click the <strong>Add ROI</strong> button then drag drop, resize the white cirle to change the new ROI position and size.
+You can click the <strong>Add ROI</strong> button then drag drop, resize the white circle to change the new ROI position and size.
 Press <strong>OK</strong> or <strong>Cancel</strong> button to Add or No
 
 <p align="center">
@@ -161,7 +161,7 @@ Press <strong>OK</strong> or <strong>Cancel</strong> button to Add or No
 Or click on each cell ROI to delete ROI or merge ROIs (when you select 2 or more ROI cells)
 Press <strong>Merge ROI</strong> or <strong>Delete ROI</strong> or <strong>Cancel</strong> button to Merge or Delete or No.
 
-NWB file is overwirtten with the ROI edit information.
+NWB file is overwritten with the ROI edit information.
 
 ```{eval-rst}
 .. note::

--- a/docs/gui/workflow.md
+++ b/docs/gui/workflow.md
@@ -163,7 +163,7 @@ SNAKEMAKE and NWB SETTING buttons are for parameters for snakemake and output NW
     - By configuring this, the output NWB file includes the information set here.
     - The parameter you set here is only for your record and is not used for calculations within OptiNiSt.
     - You can leave this setting as the default.
-    - The details of NWB setting in OptiNiSt are folling.
+    - The details of NWB setting in OptiNiSt are following.
       - session_description: a description of the session where this data was generated
       - identifier: a unique text identifier for the file
       - experiment_description: general description of the experiment

--- a/docs/gui/workflow.md
+++ b/docs/gui/workflow.md
@@ -167,7 +167,7 @@ SNAKEMAKE and NWB SETTING buttons are for parameters for snakemake and output NW
       - session_description: a description of the session where this data was generated
       - identifier: a unique text identifier for the file
       - experiment_description: general description of the experiment
-      - device: device used to aquire the data (information such as manufacturer, firmware version, model etc.)
+      - device: device used to acquire the data (information such as manufacturer, firmware version, model etc.)
       - optical_channel: information about the optical channel used to acquire the data
       - imaging_plane: information about imaging such as sampling rate, excitation wave length, calcium indicator.
       - image_serises: information about imaing time

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,7 +20,7 @@ Main Features
 
 .. _issue: https://github.com/oist/optinist/issues
 .. _here: https://www.biorxiv.org/content/early/2017/07/20/061507
-.. _this paper: Comming Soon
+.. _this paper: Coming Soon
 .. _pypi: https://pypi.org/project/optinist/
 
 .. * :ref:`modindex`

--- a/docs/utils/cui_execution.md
+++ b/docs/utils/cui_execution.md
@@ -29,7 +29,7 @@ It can be executed in CUI by running `run_cluster.py`.
 
 The parameter arguments are as follows.
 - config(string): path of config.yaml file set in step 1
-- cores(int): Specifies the number of CPU cores. (defalt: 2, cores >= 2)
+- cores(int): Specifies the number of CPU cores. (default: 2, cores >= 2)
 - forceall(bool): Whether to overwrite existing results or not. (default: false)
 - use_conda(bool): Whether to use the conda virtual environment or not. If not, it is necessary to have caiman, suite2p, etc. INSTALL the current environment into the execution environment.
 

--- a/frontend/src/components/FlowChart/TreeView.tsx
+++ b/frontend/src/components/FlowChart/TreeView.tsx
@@ -298,7 +298,7 @@ const LeafItem = styled(TreeItem)({
 })
 
 function useLeafItemDrag(
-  onDragEnd: (positon: { x: number; y: number }) => void,
+  onDragEnd: (position: { x: number; y: number }) => void,
 ) {
   const [{ isDragging }, dragRef] = useDrag<
     TreeItemDragObject,

--- a/frontend/src/store/slice/FileUploader/FileUploaderActions.ts
+++ b/frontend/src/store/slice/FileUploader/FileUploaderActions.ts
@@ -6,7 +6,7 @@ import { FILE_UPLOADER_SLICE_NAME } from './FileUploaderType'
 
 export const setUploadProgress = createAction<{
   requestId: string
-  progess: number
+  progress: number
   total: number
 }>(`${FILE_UPLOADER_SLICE_NAME}/setUploadProgress`)
 
@@ -29,7 +29,7 @@ export const uploadFile = createAsyncThunk<
         thunkAPI.dispatch(
           setUploadProgress({
             requestId,
-            progess: percent,
+            progress: percent,
             total,
           }),
         )

--- a/frontend/src/store/slice/FileUploader/FileUploaderSlice.ts
+++ b/frontend/src/store/slice/FileUploader/FileUploaderSlice.ts
@@ -16,8 +16,8 @@ export const fileUploaderSlice = createSlice({
   extraReducers: (builder) => {
     builder
       .addCase(setUploadProgress, (state, action) => {
-        const { progess, requestId } = action.payload
-        state[requestId].uploadingProgress = progess
+        const { progress, requestId } = action.payload
+        state[requestId].uploadingProgress = progress
       })
       .addCase(uploadFile.pending, (state, action) => {
         const { fileName, requestId } = action.meta.arg

--- a/optinist/api/dataclass/bar.py
+++ b/optinist/api/dataclass/bar.py
@@ -16,7 +16,7 @@ class BarData(BaseData):
         if data.ndim == 1:
             data = data[np.newaxis]
 
-        assert data.ndim == 2, "Bar Dimesion is not 2"
+        assert data.ndim == 2, "Bar Dimension is not 2"
 
         self.data = data
 

--- a/optinist/api/edit_ROI/edit_ROI.py
+++ b/optinist/api/edit_ROI/edit_ROI.py
@@ -55,7 +55,7 @@ class EditROI:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST)
         return algo
 
-    def excute(self):
+    def execute(self):
         self.set_smk_config()
 
         snakemake(
@@ -93,7 +93,7 @@ class EditRoiUtils:
         return None
 
     @classmethod
-    def excute(cls, config):
+    def execute(cls, config):
         from optinist.api.edit_ROI import edit_roi_wrapper_dict
 
         algo = config["algo"]

--- a/optinist/api/edit_ROI/wrappers/__init__.py
+++ b/optinist/api/edit_ROI/wrappers/__init__.py
@@ -1,17 +1,17 @@
 from optinist.api.edit_ROI.wrappers.caiman_edit_roi import (
-    excute_delete_roi as caiman_delete,
+    execute_delete_roi as caiman_delete,
 )
 from optinist.api.edit_ROI.wrappers.caiman_edit_roi import execute_add_ROI as caiman_add
 from optinist.api.edit_ROI.wrappers.caiman_edit_roi import (
     execute_merge_roi as caiman_merge,
 )
 from optinist.api.edit_ROI.wrappers.lccd_edit_roi import (
-    excute_delete_roi as lccd_delete,
+    execute_delete_roi as lccd_delete,
 )
 from optinist.api.edit_ROI.wrappers.lccd_edit_roi import execute_add_ROI as lccd_add
 from optinist.api.edit_ROI.wrappers.lccd_edit_roi import execute_merge_roi as lccd_merge
 from optinist.api.edit_ROI.wrappers.suite2p_edit_roi import (
-    excute_delete_roi as suite2p_delete,
+    execute_delete_roi as suite2p_delete,
 )
 from optinist.api.edit_ROI.wrappers.suite2p_edit_roi import (
     execute_add_ROI as suite2p_add,

--- a/optinist/api/edit_ROI/wrappers/caiman_edit_roi/__init__.py
+++ b/optinist/api/edit_ROI/wrappers/caiman_edit_roi/__init__.py
@@ -1,5 +1,5 @@
 from optinist.api.edit_ROI.wrappers.caiman_edit_roi.add_roi import execute_add_ROI
-from optinist.api.edit_ROI.wrappers.caiman_edit_roi.delete_roi import excute_delete_roi
+from optinist.api.edit_ROI.wrappers.caiman_edit_roi.delete_roi import execute_delete_roi
 from optinist.api.edit_ROI.wrappers.caiman_edit_roi.merge_roi import execute_merge_roi
 
-__all__ = ["execute_add_ROI", "excute_delete_roi", "execute_merge_roi"]
+__all__ = ["execute_add_ROI", "execute_delete_roi", "execute_merge_roi"]

--- a/optinist/api/edit_ROI/wrappers/caiman_edit_roi/delete_roi.py
+++ b/optinist/api/edit_ROI/wrappers/caiman_edit_roi/delete_roi.py
@@ -2,7 +2,7 @@ from optinist.api.dataclass.dataclass import CaimanCnmfData, RoiData
 from optinist.api.edit_ROI.wrappers.caiman_edit_roi.utils import set_nwbfile
 
 
-def excute_delete_roi(node_dirpath, ids):
+def execute_delete_roi(node_dirpath, ids):
     import numpy as np
 
     # load data

--- a/optinist/api/edit_ROI/wrappers/caiman_edit_roi/utils.py
+++ b/optinist/api/edit_ROI/wrappers/caiman_edit_roi/utils.py
@@ -22,7 +22,7 @@ def set_nwbfile(cnmf_data):
     nwbfile[NWBDATASET.COLUMN] = {
         "roi_column": {
             "name": "iscell",
-            "discription": "two columns - iscell & probcell",
+            "description": "two columns - iscell & probcell",
             "data": is_cell,
         }
     }

--- a/optinist/api/edit_ROI/wrappers/lccd_edit_roi/__init__.py
+++ b/optinist/api/edit_ROI/wrappers/lccd_edit_roi/__init__.py
@@ -1,5 +1,5 @@
 from optinist.api.edit_ROI.wrappers.lccd_edit_roi.add_roi import execute_add_ROI
-from optinist.api.edit_ROI.wrappers.lccd_edit_roi.delete_roi import excute_delete_roi
+from optinist.api.edit_ROI.wrappers.lccd_edit_roi.delete_roi import execute_delete_roi
 from optinist.api.edit_ROI.wrappers.lccd_edit_roi.merge_roi import execute_merge_roi
 
-__all__ = ["execute_add_ROI", "excute_delete_roi", "execute_merge_roi"]
+__all__ = ["execute_add_ROI", "execute_delete_roi", "execute_merge_roi"]

--- a/optinist/api/edit_ROI/wrappers/lccd_edit_roi/delete_roi.py
+++ b/optinist/api/edit_ROI/wrappers/lccd_edit_roi/delete_roi.py
@@ -4,7 +4,7 @@ from optinist.api.dataclass.dataclass import FluoData, LccdData, RoiData
 from optinist.api.edit_ROI.wrappers.lccd_edit_roi.utils import set_nwbfile
 
 
-def excute_delete_roi(node_dirpath, ids):
+def execute_delete_roi(node_dirpath, ids):
     import numpy as np
 
     lccd_data = np.load(

--- a/optinist/api/edit_ROI/wrappers/lccd_edit_roi/utils.py
+++ b/optinist/api/edit_ROI/wrappers/lccd_edit_roi/utils.py
@@ -19,7 +19,7 @@ def set_nwbfile(lccd_data, roi_list, fluorescence=None):
     nwbfile[NWBDATASET.COLUMN] = {
         "roi_column": {
             "name": "iscell",
-            "discription": "two columns - iscell & probcell",
+            "description": "two columns - iscell & probcell",
             "data": lccd_data.get("is_cell"),
         }
     }

--- a/optinist/api/edit_ROI/wrappers/suite2p_edit_roi/__init__.py
+++ b/optinist/api/edit_ROI/wrappers/suite2p_edit_roi/__init__.py
@@ -1,5 +1,5 @@
 from optinist.api.edit_ROI.wrappers.suite2p_edit_roi.add_roi import execute_add_ROI
-from optinist.api.edit_ROI.wrappers.suite2p_edit_roi.delete_roi import excute_delete_roi
+from optinist.api.edit_ROI.wrappers.suite2p_edit_roi.delete_roi import execute_delete_roi
 from optinist.api.edit_ROI.wrappers.suite2p_edit_roi.merge_roi import execute_merge_roi
 
-__all__ = ["execute_add_ROI", "excute_delete_roi", "execute_merge_roi"]
+__all__ = ["execute_add_ROI", "execute_delete_roi", "execute_merge_roi"]

--- a/optinist/api/edit_ROI/wrappers/suite2p_edit_roi/delete_roi.py
+++ b/optinist/api/edit_ROI/wrappers/suite2p_edit_roi/delete_roi.py
@@ -6,7 +6,7 @@ from optinist.api.dataclass.dataclass import RoiData, Suite2pData
 from optinist.api.edit_ROI.wrappers.suite2p_edit_roi.utils import set_nwbfile
 
 
-def excute_delete_roi(node_dirpath, ids):
+def execute_delete_roi(node_dirpath, ids):
     ops = np.load(os.path.join(node_dirpath, "suite2p.npy"), allow_pickle=True).item()
     iscell = ops.get("iscell")
     delete_roi = ops.get("delete_roi", [])

--- a/optinist/api/edit_ROI/wrappers/suite2p_edit_roi/utils.py
+++ b/optinist/api/edit_ROI/wrappers/suite2p_edit_roi/utils.py
@@ -140,7 +140,7 @@ def set_nwbfile(ops):
     nwbfile[NWBDATASET.COLUMN] = {
         "roi_column": {
             "name": "iscell",
-            "discription": "two columns - iscell & probcell",
+            "description": "two columns - iscell & probcell",
             "data": iscell,
         }
     }

--- a/optinist/api/nwb/nwb_creater.py
+++ b/optinist/api/nwb/nwb_creater.py
@@ -151,12 +151,12 @@ class NWBCreater:
         return nwbfile
 
     @classmethod
-    def column(cls, nwbfile, name, discription, data):
+    def column(cls, nwbfile, name, description, data):
         data_interfaces = nwbfile.processing["ophys"].data_interfaces
         plane_seg = data_interfaces["ImageSegmentation"].plane_segmentations[
             "PlaneSegmentation"
         ]
-        plane_seg.add_column(name, discription, data)
+        plane_seg.add_column(name, description, data)
 
         return nwbfile
 

--- a/optinist/api/rules/edit_ROI.py
+++ b/optinist/api/rules/edit_ROI.py
@@ -13,4 +13,4 @@ from optinist.api.edit_ROI import EditRoiUtils
 
 if __name__ == "__main__":
     config = snakemake.config
-    EditRoiUtils.excute(config)
+    EditRoiUtils.execute(config)

--- a/optinist/api/rules/file_writer.py
+++ b/optinist/api/rules/file_writer.py
@@ -27,7 +27,7 @@ class FileWriter:
                 rule_config.return_arg
             ]
         else:
-            assert False, "NodeType doesn't exsits"
+            assert False, "NodeType doesn't exist"
 
         nwbfile.pop("image_series", None)
         info["nwbfile"] = {"input": nwbfile}

--- a/optinist/routers/outputs.py
+++ b/optinist/routers/outputs.py
@@ -167,7 +167,7 @@ async def get_image(
     tags=["outputs"],
 )
 async def add_roi(filepath: str, pos: RoiPos):
-    EditROI(action=ACTION.ADD, filepath=filepath, params=pos.dict()).excute()
+    EditROI(action=ACTION.ADD, filepath=filepath, params=pos.dict()).execute()
     return EditRoiSuccess(max_index=0)
 
 
@@ -177,7 +177,7 @@ async def add_roi(filepath: str, pos: RoiPos):
     tags=["outputs"],
 )
 async def merge_roi(filepath: str, roi_list: RoiList):
-    EditROI(action=ACTION.MERGE, filepath=filepath, params=roi_list.dict()).excute()
+    EditROI(action=ACTION.MERGE, filepath=filepath, params=roi_list.dict()).execute()
     return EditRoiSuccess(max_index=0)
 
 
@@ -187,7 +187,7 @@ async def merge_roi(filepath: str, roi_list: RoiList):
     tags=["outputs"],
 )
 async def delete_roi(filepath: str, roi_list: RoiList):
-    EditROI(action=ACTION.DELETE, filepath=filepath, params=roi_list.dict()).excute()
+    EditROI(action=ACTION.DELETE, filepath=filepath, params=roi_list.dict()).execute()
     return EditRoiSuccess(max_index=0)
 
 

--- a/optinist/wrappers/caiman_wrapper/cnmf.py
+++ b/optinist/wrappers/caiman_wrapper/cnmf.py
@@ -186,7 +186,7 @@ def caiman_cnmf(
     nwbfile[NWBDATASET.COLUMN] = {
         "roi_column": {
             "name": "iscell",
-            "discription": "two columns - iscell & probcell",
+            "description": "two columns - iscell & probcell",
             "data": iscell,
         }
     }

--- a/optinist/wrappers/lccd_wrapper/lccd_detection.py
+++ b/optinist/wrappers/lccd_wrapper/lccd_detection.py
@@ -50,7 +50,7 @@ def lccd_detect(
     nwbfile[NWBDATASET.COLUMN] = {
         "roi_column": {
             "name": "iscell",
-            "discription": "two columns - iscell & probcell",
+            "description": "two columns - iscell & probcell",
             "data": is_cell,
         }
     }

--- a/optinist/wrappers/lccd_wrapper/lccd_python/blob_detector.py
+++ b/optinist/wrappers/lccd_wrapper/lccd_python/blob_detector.py
@@ -82,7 +82,7 @@ class BlobDetector:
         lumi_map = np.maximum(
             self.conv2(max_lumi_map, self.sp_fil, mode="same"),
             # Here, the article says the mode is 'valid' (Algorithm2, line 10).
-            # But in order that ROI have the dimesion (0, 1)^{XY x N_r} (line 21),
+            # But in order that ROI have the dimension (0, 1)^{XY x N_r} (line 21),
             # mode should be 'same'.
             0,
         )

--- a/optinist/wrappers/lccd_wrapper/lccd_python/roi_integration.py
+++ b/optinist/wrappers/lccd_wrapper/lccd_python/roi_integration.py
@@ -10,7 +10,7 @@ def filter_roi_by_area(roi, min_area, max_area):
     ----------
     roi: np.array or scipy.sparse.csc (Maybe work with other sparse matrix types)
         roi has shape (X, n).
-        X is spacial dimension.
+        X is spatial dimension.
         n is the number of rois
     min_area: int
     max_area: int

--- a/optinist/wrappers/lccd_wrapper/lccd_python/utils.py
+++ b/optinist/wrappers/lccd_wrapper/lccd_python/utils.py
@@ -54,7 +54,7 @@ def insert_binary_col_binary_csc(mat, indices, i=None):
     ]       ^ Inserted column
 
     When indices = np.array([0, 2]),
-    The colum to be inserted is
+    The column to be inserted is
     [
         [1],
         [0],

--- a/optinist/wrappers/optinist_wrapper/dimension_reduction/cca.py
+++ b/optinist/wrappers/optinist_wrapper/dimension_reduction/cca.py
@@ -22,7 +22,7 @@ def CCA(
     neural_data = neural_data.data
     behaviors_data = behaviors_data.data
 
-    # data shold be time x component matrix
+    # data should be time x component matrix
     if params["transpose_x"]:
         X = neural_data.transpose()
     else:

--- a/optinist/wrappers/optinist_wrapper/dimension_reduction/pca.py
+++ b/optinist/wrappers/optinist_wrapper/dimension_reduction/pca.py
@@ -15,7 +15,7 @@ def PCA(
 
     neural_data = neural_data.data
 
-    # data shold be time x component matrix
+    # data should be time x component matrix
     if params["transpose"]:
         X = neural_data.transpose()
     else:

--- a/optinist/wrappers/optinist_wrapper/dimension_reduction/tsne.py
+++ b/optinist/wrappers/optinist_wrapper/dimension_reduction/tsne.py
@@ -14,7 +14,7 @@ def TSNE(
 
     neural_data = neural_data.data
 
-    # data shold be time x component matrix
+    # data should be time x component matrix
     if params["transpose"]:
         X = neural_data.transpose()
     else:

--- a/optinist/wrappers/optinist_wrapper/neural_decoding/glm.py
+++ b/optinist/wrappers/optinist_wrapper/neural_decoding/glm.py
@@ -31,7 +31,7 @@ def GLM(
     neural_data = neural_data.data
     behaviors_data = behaviors_data.data
 
-    # data shold be time x component matrix
+    # data should be time x component matrix
     if params["transpose_x"]:
         X = neural_data.transpose()
     else:

--- a/optinist/wrappers/optinist_wrapper/neural_decoding/lda.py
+++ b/optinist/wrappers/optinist_wrapper/neural_decoding/lda.py
@@ -18,7 +18,7 @@ def LDA(
     neural_data = neural_data.data
     behaviors_data = behaviors_data.data
 
-    # data shold be time x component matrix
+    # data should be time x component matrix
     if params["transpose_x"]:
         X = neural_data.transpose()
     else:

--- a/optinist/wrappers/optinist_wrapper/neural_decoding/svm.py
+++ b/optinist/wrappers/optinist_wrapper/neural_decoding/svm.py
@@ -18,7 +18,7 @@ def SVM(
     neural_data = neural_data.data
     behaviors_data = behaviors_data.data
 
-    # data shold be time x component matrix
+    # data should be time x component matrix
     if params["transpose_x"]:
         X = neural_data.transpose()
     else:

--- a/optinist/wrappers/optinist_wrapper/neural_population_analysis/correlation.py
+++ b/optinist/wrappers/optinist_wrapper/neural_population_analysis/correlation.py
@@ -12,7 +12,7 @@ def correlation(
 
     neural_data = neural_data.data
 
-    # data shold be time x component matrix
+    # data should be time x component matrix
     if params["transpose"]:
         X = neural_data.transpose()
     else:

--- a/optinist/wrappers/optinist_wrapper/neural_population_analysis/cross_correlation.py
+++ b/optinist/wrappers/optinist_wrapper/neural_population_analysis/cross_correlation.py
@@ -17,7 +17,7 @@ def cross_correlation(
 
     neural_data = neural_data.data
 
-    # data shold be time x component matrix
+    # data should be time x component matrix
     if params["transpose"]:
         X = neural_data.transpose()
     else:

--- a/optinist/wrappers/optinist_wrapper/neural_population_analysis/granger.py
+++ b/optinist/wrappers/optinist_wrapper/neural_population_analysis/granger.py
@@ -119,7 +119,7 @@ def Granger(
         # The Null hypothesis for grangercausalitytests is
         # that the time series in the second column1,
         # does NOT Granger cause the time series in the first column0
-        # column 1 -> colum 0
+        # column 1 -> column 0
         tp = grangercausalitytests(
             tX[:, [comb[i][0], comb[i][1]]],
             params["Granger_maxlag"],

--- a/optinist/wrappers/optinist_wrapper/neural_population_analysis/granger.py
+++ b/optinist/wrappers/optinist_wrapper/neural_population_analysis/granger.py
@@ -24,7 +24,7 @@ def Granger(
 
     neural_data = neural_data.data
 
-    # data shold be time x component matrix
+    # data should be time x component matrix
     if params["transpose"]:
         X = neural_data.transpose()
     else:

--- a/optinist/wrappers/suite2p_wrapper/edit_roi/delete_roi.py
+++ b/optinist/wrappers/suite2p_wrapper/edit_roi/delete_roi.py
@@ -5,7 +5,7 @@ import numpy as np
 from optinist.wrappers.suite2p_wrapper.edit_roi.utils import save_json_data
 
 
-def excute_delete_roi(node_dirpath, delete_roi_ids):
+def execute_delete_roi(node_dirpath, delete_roi_ids):
     ops = np.load(os.path.join(node_dirpath, "suite2p.npy"), allow_pickle=True).item()
     iscell = ops.get("iscell")
     im = ops.get("im")

--- a/optinist/wrappers/suite2p_wrapper/roi.py
+++ b/optinist/wrappers/suite2p_wrapper/roi.py
@@ -72,7 +72,7 @@ def suite2p_roi(
     nwbfile[NWBDATASET.COLUMN] = {
         "roi_column": {
             "name": "iscell",
-            "discription": "two columns - iscell & probcell",
+            "description": "two columns - iscell & probcell",
             "data": iscell,
         }
     }


### PR DESCRIPTION
note that some typo fixes are "functional" - fixing (I think) possible issues which might have lingered around and were not detected due to not being unittests covered?
Also note that some typos are "incorporated" within pickled files, e.g.

```shell
❯ git grep discription
Binary file sample_data/workflows/output/51009510/caiman_cnmf_1qpzy3hekw/caiman_cnmf.pkl matches
Binary file sample_data/workflows/output/51009510/correlation_ribhh6ohae/correlation.pkl matches
Binary file sample_data/workflows/output/51009510/eta_ulbn0meve0/eta.pkl matches
Binary file sample_data/workflows/output/7f8fbba5/correlation_onyx5cah3a/correlation.pkl matches
Binary file sample_data/workflows/output/7f8fbba5/suite2p_roi_ib1necv3e5/suite2p_roi.pkl matches

```
Not sure if it has any ramification