### PR TITLE
set default values for frontend env

### DIFF
--- a/frontend/src/const/API.ts
+++ b/frontend/src/const/API.ts
@@ -1,5 +1,5 @@
-const HOST = process.env.REACT_APP_SERVER_HOST
-const PORT = process.env.REACT_APP_SERVER_PORT
+const HOST = process.env.REACT_APP_SERVER_HOST ?? 'localhost'
+const PORT = process.env.REACT_APP_SERVER_PORT ?? 8000
 
 export const BASE_URL = `http://${HOST}:${PORT}`
 export const WS_BASE_URL = `ws://${HOST}:${PORT}`


### PR DESCRIPTION
fix issue frontend can't find BE server without .env.development
