### PR TITLE
fix visualize crash

### DIFF
--- a/frontend/src/store/slice/VisualizeItem/VisualizeItemSlice.ts
+++ b/frontend/src/store/slice/VisualizeItem/VisualizeItemSlice.ts
@@ -1,4 +1,4 @@
-import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { createSlice, isAnyOf, PayloadAction } from '@reduxjs/toolkit'
 import { DATA_TYPE, DATA_TYPE_SET } from '../DisplayData/DisplayDataType'
 import {
   deleteDisplayItem,
@@ -39,6 +39,7 @@ import {
   isLineItem,
   isPolarItem,
 } from './VisualizeItemUtils'
+import { run, runByCurrentUid } from '../Pipeline/PipelineActions'
 
 export const initialState: VisualaizeItem = {
   items: {},
@@ -923,6 +924,10 @@ export const visualaizeItemSlice = createSlice({
           }
         })
       })
+      .addMatcher(
+        isAnyOf(run.fulfilled, runByCurrentUid.fulfilled),
+        (state, action) => initialState,
+      )
   },
 })
 


### PR DESCRIPTION
- Create and Run new pipeline with plots of the last workflow visualized, crashes on switching tabs.
- Clear plots to keep state fresh on RUN, RUN_ALL